### PR TITLE
Use test project and service account for testing

### DIFF
--- a/pybigquery/api.py
+++ b/pybigquery/api.py
@@ -7,14 +7,15 @@ from google.cloud.bigquery import Client, QueryJobConfig
 
 
 class ApiClient(object):
-    def __init__(self, credentials_path=None, location=None):
+    def __init__(self, project=None, credentials_path=None, location=None):
         self.credentials_path = credentials_path
         self.location = location
+        self.project = project
         if self.credentials_path:
             self.client = Client.from_service_account_json(
-                self.credentials_path, location=self.location)
+                self.credentials_path, location=self.location, project=self.project)
         else:
-            self.client = Client(location=self.location)
+            self.client = Client(location=self.location, project=self.project)
 
     def dry_run_query(self, query):
         job_config = QueryJobConfig()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name="pybigquery",
-    version='0.5.1',
+    version='0.5.4',
     description="SQLAlchemy dialect for BigQuery",
     long_description=readme(),
     long_description_content_type="text/x-rst",

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from google.api_core.exceptions import BadRequest
+from google.cloud import secretmanager
 from pybigquery.api import ApiClient
 from pybigquery.sqlalchemy_bigquery import BigQueryDialect
 from sqlalchemy.engine import create_engine
@@ -16,7 +17,10 @@ import pytest
 import sqlalchemy
 import datetime
 import decimal
+from tempfile import NamedTemporaryFile
 
+
+TEST_PROJECT = 'data-pipelines-tests-298816'
 
 ONE_ROW_CONTENTS_EXPANDED = [
     588,
@@ -98,8 +102,19 @@ SAMPLE_COLUMNS = [
 
 
 @pytest.fixture(scope='session')
-def engine():
-    engine = create_engine('bigquery://', echo=True)
+def test_service_account_key():
+    client = secretmanager.SecretManagerServiceClient()
+    name = client.secret_version_path(TEST_PROJECT, 'data-pipelines-bq-tests-service-account', 1)
+    response = client.access_secret_version(name)
+    with NamedTemporaryFile(suffix='.json') as key_file:
+        key_file.write(response.payload.data.decode('UTF-8'))
+        key_file.flush()
+        yield key_file.name
+
+
+@pytest.fixture(scope='session')
+def engine(test_service_account_key):
+    engine = create_engine('bigquery://{}'.format(TEST_PROJECT), echo=True, credentials_path=test_service_account_key)
     return engine
 
 
@@ -109,14 +124,16 @@ def dialect():
 
 
 @pytest.fixture(scope='session')
-def engine_using_test_dataset():
-    engine = create_engine('bigquery:///test_pybigquery', echo=True)
+def engine_using_test_dataset(test_service_account_key):
+    engine = create_engine('bigquery://{}/test_pybigquery'.format(TEST_PROJECT), echo=True,
+                           credentials_path=test_service_account_key)
     return engine
 
 
 @pytest.fixture(scope='session')
-def engine_with_location():
-    engine = create_engine('bigquery://', echo=True, location="asia-northeast1")
+def engine_with_location(test_service_account_key):
+    engine = create_engine('bigquery://{}'.format(TEST_PROJECT), echo=True, location="asia-northeast1",
+                           credentials_path=test_service_account_key)
     return engine
 
 
@@ -187,8 +204,8 @@ def query():
 
 
 @pytest.fixture(scope='session')
-def api_client():
-    return ApiClient()
+def api_client(test_service_account_key):
+    return ApiClient(project=TEST_PROJECT, credentials_path=test_service_account_key)
 
 
 def test_dry_run(engine, api_client):


### PR DESCRIPTION
Make sure we are using a separate project and service account created specifically for BQ testing.  Will apply this approach to data-pipelines tests once they are using BQ.