### PR TITLE
Make inclusion of table name prefixes in query optional

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -143,7 +143,7 @@ class BigQueryCompiler(SQLCompiler):
         This ensures that fields won't contain duplicate names
         """
 
-        args[0].use_labels = True
+        args[0].use_labels = kwargs.get("use_labels", True)
         return super(BigQueryCompiler, self).visit_select(*args, **kwargs)
 
     def visit_column(self, column, add_to_result_map=None,
@@ -287,6 +287,7 @@ class BigQueryDialect(DefaultDialect):
             location=None,
             credentials_info=None,
             use_schema_in_column_references=False,
+            include_table_name_in_selected_columns=True,
             *args, **kwargs):
         super(BigQueryDialect, self).__init__(*args, **kwargs)
         self.arraysize = arraysize
@@ -295,6 +296,7 @@ class BigQueryDialect(DefaultDialect):
         self.location = location,
         self.use_schema_in_column_references = use_schema_in_column_references
         self.dataset_id = None
+        self.include_table_name_in_selected_columns = include_table_name_in_selected_columns
 
     @classmethod
     def dbapi(cls):

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -287,7 +287,6 @@ class BigQueryDialect(DefaultDialect):
             location=None,
             credentials_info=None,
             use_schema_in_column_references=False,
-            include_table_name_in_selected_columns=True,
             *args, **kwargs):
         super(BigQueryDialect, self).__init__(*args, **kwargs)
         self.arraysize = arraysize
@@ -296,7 +295,6 @@ class BigQueryDialect(DefaultDialect):
         self.location = location,
         self.use_schema_in_column_references = use_schema_in_column_references
         self.dataset_id = None
-        self.include_table_name_in_selected_columns = include_table_name_in_selected_columns
 
     @classmethod
     def dbapi(cls):

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -139,10 +139,8 @@ class BigQueryCompiler(SQLCompiler):
 
     def visit_select(self, *args, **kwargs):
         """
-        Use labels for every column.
-        This ensures that fields won't contain duplicate names
+        Use labels for every column by default to ensures that fields won't contain duplicate names
         """
-
         args[0].use_labels = kwargs.get("use_labels", True)
         return super(BigQueryCompiler, self).visit_select(*args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name="pybigquery",
-    version='0.5.3',
+    version='0.5.4',
     description="SQLAlchemy dialect for BigQuery",
     long_description=readme(),
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name="pybigquery",
-    version='0.5.4',
+    version='0.5.5',
     description="SQLAlchemy dialect for BigQuery",
     long_description=readme(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Add ability to pass `compile_kwargs={'use_labels': False}` to compile calls to prevent column names from being prefixed with the table name.  

This allows for queries to be converted to pandas dataframes w/out needing to to adjust column names on the pandas side.  