### PR TITLE
Use schema mapper in reflection

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -436,6 +436,7 @@ class BigQueryDialect(DefaultDialect):
 
     def _get_table_or_view_names(self, connection, table_type, schema=None):
         current_schema = schema or self.dataset_id
+        current_schema = connection.schema_for_object.map_[current_schema]
         get_table_name = self._build_formatted_table_id \
             if self.dataset_id is None else \
             operator.attrgetter("table_id")

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -446,7 +446,7 @@ class BigQueryDialect(DefaultDialect):
 
         result = []
         for dataset in datasets:
-            if current_schema is not None and current_schema != dataset.dataset_id:
+            if current_schema is not None and current_schema != connection.schema_for_object.map_[dataset.dataset_id]:
                 continue
 
             tables = client.list_tables(dataset.reference)

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -446,7 +446,7 @@ class BigQueryDialect(DefaultDialect):
 
         result = []
         for dataset in datasets:
-            if current_schema is not None and current_schema != connection.schema_for_object.map_[dataset.dataset_id]:
+            if current_schema is not None and current_schema != dataset.dataset_id:
                 continue
 
             tables = client.list_tables(dataset.reference)

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -436,7 +436,8 @@ class BigQueryDialect(DefaultDialect):
 
     def _get_table_or_view_names(self, connection, table_type, schema=None):
         current_schema = schema or self.dataset_id
-        current_schema = connection.schema_for_object.map_[current_schema]
+        if connection.schema_for_object.map_:
+            current_schema = connection.schema_for_object.map_[current_schema]
         get_table_name = self._build_formatted_table_id \
             if self.dataset_id is None else \
             operator.attrgetter("table_id")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name="pybigquery",
-    version='0.5.5',
+    version='0.5.6',
     description="SQLAlchemy dialect for BigQuery",
     long_description=readme(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
If the connection has a `schema_translate_map` defined, use it to translate the given `dataset_id` when reflecting tables.  

(required to support parallel test runs by running against isolated datasets)