### PR TITLE
Include external tables in reflection

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import operator
+import six
 
 from google import auth
 from google.cloud import bigquery
@@ -434,7 +435,7 @@ class BigQueryDialect(DefaultDialect):
         """
         return row
 
-    def _get_table_or_view_names(self, connection, table_type, schema=None):
+    def _get_table_or_view_names(self, connection, table_types, schema=None):
         current_schema = schema or self.dataset_id
         if connection.schema_for_object.map_:
             current_schema = connection.schema_for_object.map_[current_schema]
@@ -452,7 +453,7 @@ class BigQueryDialect(DefaultDialect):
 
             tables = client.list_tables(dataset.reference)
             for table in tables:
-                if table_type == table.table_type:
+                if table.table_type in table_types:
                     result.append(get_table_name(table))
         return result
 
@@ -610,13 +611,13 @@ class BigQueryDialect(DefaultDialect):
         if isinstance(connection, Engine):
             connection = connection.connect()
 
-        return self._get_table_or_view_names(connection, "TABLE", schema)
+        return self._get_table_or_view_names(connection, {"TABLE", "EXTERNAL"}, schema)
 
     def get_view_names(self, connection, schema=None, **kw):
         if isinstance(connection, Engine):
             connection = connection.connect()
 
-        return self._get_table_or_view_names(connection, "VIEW", schema)
+        return self._get_table_or_view_names(connection, {"VIEW"}, schema)
 
     def do_rollback(self, dbapi_connection):
         # BigQuery has no support for transactions.

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import operator
-import six
 
 from google import auth
 from google.cloud import bigquery

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name="pybigquery",
-    version='0.5.6',
+    version='0.5.7',
     description="SQLAlchemy dialect for BigQuery",
     long_description=readme(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Resolves an issue where external tables could not be reflected.

Note: This wasn't caught in `data-pipelines` unit tests b/c `raw_prediction` table is created as a non-external table in the test context.  