### PR TITLE
Insert CTE After Insert Clause

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -343,6 +343,7 @@ class BigQueryDialect(DefaultDialect):
     supports_native_boolean = True
     supports_simple_order_by_label = True
     postfetch_lastrowid = False
+    cte_follows_insert = True
 
     def __init__(
             self,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(
     name="pybigquery",
-    version='0.5.7',
+    version='0.5.8',
     description="SQLAlchemy dialect for BigQuery",
     long_description=readme(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Set cte_follows_insert=True on dialect to force SQLA to render CTE clauses after an Insert clause.

Before:
```
WITH cte AS (
   ....
)
INSERT ...
```


After:
```
INSERT ... 
WITH cte AS (
    ....
)
```